### PR TITLE
Fix always writing statusCounts

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -576,8 +576,11 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 
 	// Pointer-swap the decoded pagination details.
 	pagination.Set(reflect.ValueOf(&m.Pagination))
-	statusCounts.Set(reflect.ValueOf(&m.StatusCounts))
 
+	// Only include statusCounts if we have them
+	if statusCounts.CanAddr() {
+		statusCounts.Set(reflect.ValueOf(&m.StatusCounts))
+	}
 	return nil
 }
 


### PR DESCRIPTION
We were creating struct fields for Items, Pagination, and StatusCounts for all requests by using reflect.Indirect.FieldByName without verifying later on that those struct fields exist and can be written to. This check explicitly queries to see if we can write to statusCounts as the docs on standard API responses from TFE always include Items and Pagination.